### PR TITLE
Add platforms in package.json

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -4,6 +4,12 @@
 	"description": "Your Take a View Screenshot Nativescript Plugin!",
 	"main": "cscreenshot",
 	"typings": "index.d.ts",
+	"nativescript": {
+		"platforms": {
+			"android": "7.0.1",
+			"ios": "7.0.4"
+		}
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/enduco/nativescript-cscreenshot.git"


### PR DESCRIPTION
Otherwise it fails when doing `ns plugin add @enduco/nativescript-cscreenshot` (seems a quite old bug of the NS CLI, see https://github.com/NativeScript/nativescript-cli/issues/3123)